### PR TITLE
Fixed misalignment of "Browse All" in FireFox

### DIFF
--- a/components/Featured.tsx
+++ b/components/Featured.tsx
@@ -124,6 +124,13 @@ export const Featured: FC = () => {
                     right: 0,
                     top: 0,
                     bottom: 0,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    textAlign: 'center',
+                    width: '100%',
+                    height: '100%',
                   }}
                 >
                   <Stack alignItems="center" justifyContent="center" gap={0.5}>


### PR DESCRIPTION
This is how the vercel deployment and the local build was looking like
![image](https://github.com/ctate/codeless/assets/83471520/aab57b1c-a16e-47c6-a7bd-4ac3d680f44c)
So after the basic CSS fix this is how it looks
![image](https://github.com/ctate/codeless/assets/83471520/cc9c28ca-8ddd-4397-b950-857dc864eeeb)

